### PR TITLE
[Feat] 낱말퀴즈 단어 추가

### DIFF
--- a/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/config/FlipCardDataInitializer.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/config/FlipCardDataInitializer.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,6 +25,7 @@ public class FlipCardDataInitializer implements CommandLineRunner {
     private final FlipCardRepository flipCardRepository;
 
     @Override
+    @Transactional
     public void run(String... args) throws Exception {
         if (flipCardRepository.count() > 0) {
             log.info("FlipCard 데이터가 이미 존재합니다.");

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/config/FlipCardDataInitializer.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/config/FlipCardDataInitializer.java
@@ -1,10 +1,10 @@
 package com.prgrms.ijuju.domain.minigame.flipcard.config;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.ijuju.domain.minigame.flipcard.dto.request.FlipCardDto;
 import com.prgrms.ijuju.domain.minigame.flipcard.entity.FlipCard;
+import com.prgrms.ijuju.domain.minigame.flipcard.exception.FlipCardInitializationException;
 import com.prgrms.ijuju.domain.minigame.flipcard.repository.FlipCardRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +13,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -21,33 +20,48 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class FlipCardDataInitializer implements CommandLineRunner {
+    private static final String DATA_FILE_PATH = "minigame-data/flip-card.json";
 
     private final FlipCardRepository flipCardRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
-    public void run(String... args) throws Exception {
-        if (flipCardRepository.count() > 0) {
+    public void run(String... args) {
+        try {
+            initializeFlipCardData();
+        } catch (Exception e) {
+            throw new FlipCardInitializationException("FlipCard 데이터 초기화 중 오류 발생", e);
+        }
+    }
+
+    private void initializeFlipCardData() throws IOException {
+        if (isDataAlreadyExists()) {
             log.info("FlipCard 데이터가 이미 존재합니다.");
             return;
         }
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        List<FlipCardDto> flipCardDtos = loadFlipCardData();
+        saveFlipCardData(flipCardDtos);
+        log.info("FlipCard 데이터 초기화 완료");
+    }
 
-        try {
-            ClassPathResource classPathResource = new ClassPathResource("minigame-data/flip-card.json");
-            File file = classPathResource.getFile();
+    private boolean isDataAlreadyExists() {
+        return flipCardRepository.count() > 0;
+    }
 
-            List<FlipCardDto> flipCardDtos = objectMapper.readValue(file, new TypeReference<List<FlipCardDto>>() {
-            });
-            List<FlipCard> flipCards = flipCardDtos.stream()
-                    .map(FlipCardDto::toEntity)
-                    .toList();
-            flipCardRepository.saveAll(flipCards);
-            log.info("FlipCard 데이터 초기화 완료");
-        } catch (IOException e) {
-            log.error("FlipCard 데이터 초기화 실패: {}", e.getMessage());
-        }
+    private List<FlipCardDto> loadFlipCardData() throws IOException {
+        ClassPathResource classPathResource = new ClassPathResource(DATA_FILE_PATH);
+        return objectMapper.readValue(
+                classPathResource.getInputStream(),
+                new TypeReference<List<FlipCardDto>>() {}
+        );
+    }
+
+    private void saveFlipCardData(List<FlipCardDto> flipCardDtos) {
+        List<FlipCard> flipCards = flipCardDtos.stream()
+                .map(FlipCardDto::toEntity)
+                .toList();
+        flipCardRepository.saveAll(flipCards);
     }
 }

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/exception/FlipCardInitializationException.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/flipcard/exception/FlipCardInitializationException.java
@@ -1,0 +1,7 @@
+package com.prgrms.ijuju.domain.minigame.flipcard.exception;
+
+public class FlipCardInitializationException extends RuntimeException {
+    public FlipCardInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/config/WordQuizDataInitializer.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/config/WordQuizDataInitializer.java
@@ -1,7 +1,6 @@
 package com.prgrms.ijuju.domain.minigame.wordquiz.config;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.ijuju.domain.minigame.wordquiz.dto.request.WordQuizDbDto;
 import com.prgrms.ijuju.domain.minigame.wordquiz.entity.WordQuiz;

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/config/WordQuizDataInitializer.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/config/WordQuizDataInitializer.java
@@ -1,0 +1,68 @@
+package com.prgrms.ijuju.domain.minigame.wordquiz.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.ijuju.domain.minigame.wordquiz.dto.request.WordQuizDbDto;
+import com.prgrms.ijuju.domain.minigame.wordquiz.entity.WordQuiz;
+import com.prgrms.ijuju.domain.minigame.wordquiz.exception.WordQuizInitializationException;
+import com.prgrms.ijuju.domain.minigame.wordquiz.repository.WordQuizRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WordQuizDataInitializer implements CommandLineRunner {
+    private static final String DATA_FILE_PATH = "minigame-data/korean-words-game.json";
+
+    private final WordQuizRepository wordQuizRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        try {
+            initializeWordQuizData();
+        } catch (Exception e) {
+            throw new WordQuizInitializationException("WordQuiz 데이터 초기화 중 오류 발생", e);
+        }
+    }
+
+    private void initializeWordQuizData() throws IOException {
+        if (isDataAlreadyExists()) {
+            log.info("WordQuiz 데이터가 이미 존재합니다.");
+            return;
+        }
+
+        List<WordQuizDbDto> wordQuizDbDtos = loadWordQuizData();
+        saveWordQuizData(wordQuizDbDtos);
+        log.info("WordQuiz 데이터 초기화 완료");
+    }
+
+    private boolean isDataAlreadyExists() {
+        return wordQuizRepository.count() > 0;
+    }
+
+    private List<WordQuizDbDto> loadWordQuizData() throws IOException {
+        ClassPathResource classPathResource = new ClassPathResource(DATA_FILE_PATH);
+        return objectMapper.readValue(
+                classPathResource.getInputStream(),
+                new TypeReference<List<WordQuizDbDto>>() {}
+        );
+    }
+
+    private void saveWordQuizData(List<WordQuizDbDto> wordQuizDbDtos) {
+        List<WordQuiz> wordQuizs = wordQuizDbDtos.stream()
+                .map(WordQuizDbDto::toEntity)
+                .toList();
+        wordQuizRepository.saveAll(wordQuizs);
+    }
+}

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/dto/request/WordQuizDbDto.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/dto/request/WordQuizDbDto.java
@@ -1,0 +1,35 @@
+package com.prgrms.ijuju.domain.minigame.wordquiz.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.prgrms.ijuju.domain.minigame.wordquiz.entity.WordQuiz;
+import lombok.Getter;
+
+@Getter
+public class WordQuizDbDto {
+    private String word;
+    private String explanation;
+    private String hint;
+
+    @JsonProperty("Word")
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    @JsonProperty("Description")
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    @JsonProperty("Hint")
+    public void setHint(String hint) {
+        this.hint = hint;
+    }
+
+    public WordQuiz toEntity() {
+        return WordQuiz.builder()
+                .word(this.word)
+                .explanation(this.explanation)
+                .hint(this.hint)
+                .build();
+    }
+}

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/entity/WordQuiz.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/entity/WordQuiz.java
@@ -1,0 +1,37 @@
+package com.prgrms.ijuju.domain.minigame.wordquiz.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WordQuiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String word;
+
+    @NotNull
+    private String explanation;
+
+    @NotNull
+    private String hint;
+
+    @Builder
+    public WordQuiz(String word, String explanation, String hint) {
+        this.word = word;
+        this.explanation = explanation;
+        this.hint = hint;
+    }
+}

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/exception/WordQuizInitializationException.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/exception/WordQuizInitializationException.java
@@ -1,0 +1,7 @@
+package com.prgrms.ijuju.domain.minigame.wordquiz.exception;
+
+public class WordQuizInitializationException extends RuntimeException {
+    public WordQuizInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/repository/WordQuizRepository.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/wordquiz/repository/WordQuizRepository.java
@@ -1,0 +1,7 @@
+package com.prgrms.ijuju.domain.minigame.wordquiz.repository;
+
+import com.prgrms.ijuju.domain.minigame.wordquiz.entity.WordQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WordQuizRepository extends JpaRepository<WordQuiz, Long> {
+}

--- a/src/main/java/com/prgrms/ijuju/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/prgrms/ijuju/global/config/ObjectMapperConfig.java
@@ -1,0 +1,17 @@
+package com.prgrms.ijuju.global.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+}


### PR DESCRIPTION
# closed #44


## #️⃣ 연관된 이슈 번호
https://github.com/prgrms-web-devcourse-final-project/WEB1_2_Child-Learn_BE/issues/44 낱말퀴즈 데이터 생성 완료
<br>

## ✅ PR 유형
<!-- 필요 없는 유형은 꼭 삭제해주세요. -->
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

<br>

## 📝 작업 내용
> 작업한 내용을 자세하게 설명해주세요. 필요시 스크린샷을 첨부해주세요.
- [x] 낱말퀴즈 엔티티 생성
- [x] 낱말퀴즈 데이터생성용 dto, 리포지토리 생성
- [x] 낱말퀴즈 데이터 저장 코드 구현
- [x] 공통부분에 ObjectMapperConfig 생성
- [x] 카드 뒤집기 데이터 생성코드 리팩토링


<br>

## 🔍 테스트 결과
### DB 생성 결과
![image](https://github.com/user-attachments/assets/fab8d8b0-9cba-4e49-9a39-ff06b1995d35)


<br>

## 🎈 변경 사항 체크리스트
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항


<br>

## 💬 리뷰 요구사항


<br>
