### PR TITLE
Feat: 거래량 데이터 조회 기능 추가

### DIFF
--- a/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/dto/response/AdvStockResponseDto.java
+++ b/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/dto/response/AdvStockResponseDto.java
@@ -23,6 +23,7 @@ public class AdvStockResponseDto {
     private Double lowPrice;
     private Double closePrice;
     private Long timestamp;
+    private String dataType;
 
     public static AdvStockResponseDto fromEntity(AdvStock advStock, int index) {
         return AdvStockResponseDto.builder()
@@ -33,6 +34,7 @@ public class AdvStockResponseDto {
                 .lowPrice(advStock.getLowPrices().get(index))
                 .closePrice(advStock.getClosePrices().get(index))
                 .timestamp(advStock.getTimestamps().get(index))
+                .dataType(advStock.getDataType().name())
                 .build();
     }
 }

--- a/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/handler/AdvancedInvestWebSocketHandler.java
+++ b/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/handler/AdvancedInvestWebSocketHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -55,6 +56,11 @@ public class AdvancedInvestWebSocketHandler extends TextWebSocketHandler {
                 Map<String, Object> response = new HashMap<>();
                 response.put("remainingTime", remainingTime);
                 WebSocketUtil.send(session, response); // JSON 형식으로 전송
+                break;
+
+            case "GET_VOLUMES":
+                advancedInvestService.getRecentVolumes(session, requestDto.getStockSymbol(), requestDto.getAdvId());
+                WebSocketUtil.send(session, "거래량 데이터 조회");
                 break;
 
 

--- a/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/service/AdvancedInvestService.java
+++ b/src/main/java/com/prgrms/ijuju/domain/stock/adv/advancedinvest/service/AdvancedInvestService.java
@@ -35,5 +35,6 @@ public interface AdvancedInvestService {
     // 주식 판매
     void sellStock(Long gameId, StockTransactionRequestDto request);
 
-
+    //거래량 조회
+    void getRecentVolumes(WebSocketSession session, String stockSymbol, Long gameId);
 }


### PR DESCRIPTION
프론트 측 요청으로 가장 최신의 8개의 거래량을 거래하는 기능을 구현하였습니다

related to: #51

# closed #51

## #️⃣ 연관된 이슈 번호

<br>

## ✅ PR 유형
<!-- 필요 없는 유형은 꼭 삭제해주세요. -->
- [x] 새로운 기능 추가


<br>

## 📝 작업 내용
> 
주식 거래창에서 쓰일 8개의 거래량을 따로 보내는 기능을 구현하였습니다. 

기본적으로 Counter 객체와 함께 작동합니다

- [x] startCounter 측에 LiveSentCounter map 객체를 생성하여 주입
- [x] LiveSentCounter 객체를 기준으로 가장 최신의 거래 데이터 8 개를 보내는 getRecentVolumes 메소드 구현
- [x] handler 측에 getRecentVolume 을 실행시키는 GET_VOLUMES case 생성 



<br>

## 🔍 테스트 결과
> 테스트 결과 이상 없이 volume 데이터를 가지고 옵니다

<br>

## 🎈 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항
> 피드백 받은 내용이 있으면 작성해주세요.

<br>

## 💬 리뷰 요구사항
> 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요.
ex) Student.java:29 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

<br>
