### PR TITLE
[Fix] member-CreatedAt 버그 픽스

### DIFF
--- a/src/main/java/com/prgrms/ijuju/domain/avatar/entity/Item.java
+++ b/src/main/java/com/prgrms/ijuju/domain/avatar/entity/Item.java
@@ -26,22 +26,26 @@ public class Item {
     @Enumerated(EnumType.STRING)    // 'enum'을 문자열로 저장
     private ItemCategory category;
 
+    private String imageUrl;
+
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Purchase> purchases = new ArrayList<>();
 
-    public Item(String name, String description, Long price, ItemCategory category) {
+    public Item(String name, String description, Long price, ItemCategory category, String imageUrl) {
         this.name = name;
         this.description = description;
         this.price = price;
         this.category = category;
+        this.imageUrl = imageUrl;
     }
 
     @Builder
-    public Item(String name, String description, Long price, ItemCategory category, List<Purchase> purchases) {
+    public Item(String name, String description, Long price, ItemCategory category, String imageUrl, List<Purchase> purchases) {
         this.name = name;
         this.description = description;
         this.price = price;
         this.category = category;
+        this.imageUrl = imageUrl;
         this.purchases = purchases;
     }
 }

--- a/src/main/java/com/prgrms/ijuju/domain/member/dto/response/MemberResponseDTO.java
+++ b/src/main/java/com/prgrms/ijuju/domain/member/dto/response/MemberResponseDTO.java
@@ -83,8 +83,8 @@ public class MemberResponseDTO {
             this.email = member.getEmail();
             this.pw = member.getPw();
             this.username = member.getUsername();
-//            this.createdAt = member.getCreatedAt();
-//            this.updatedAt = member.getUpdatedAt();
+            this.createdAt = member.getCreateDate();
+            this.updatedAt = member.getModifiedDate();
             this.birth = member.getBirth();
             this.points = member.getPoints();
         }
@@ -103,7 +103,7 @@ public class MemberResponseDTO {
             this.id = member.getId();
             this.loginId = member.getLoginId();
             this.username = member.getUsername();
-//            this.createdAt = member.getCreatedAt();
+            this.createdAt = member.getCreateDate();
             this.points = member.getPoints();
         }
     }

--- a/src/main/java/com/prgrms/ijuju/domain/member/entity/Member.java
+++ b/src/main/java/com/prgrms/ijuju/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.prgrms.ijuju.domain.member.entity;
 
+import com.prgrms.ijuju.domain.avatar.entity.Avatar;
 import com.prgrms.ijuju.domain.avatar.entity.Purchase;
 import com.prgrms.ijuju.domain.ranking.entity.Ranking;
 import com.prgrms.ijuju.global.common.BaseTimeEntity;
@@ -78,9 +79,10 @@ public class Member extends BaseTimeEntity {
         this.isActive=isActive;
     }
 
-//    // 회원의 아바타(착용한 아이템들을 포함)
-//    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-//    private Avatar avatar;
+    // 회원의 아바타(착용한 아이템들을 포함)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "avatar_id")
+    private Avatar avatar;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Purchase> purchases = new ArrayList<>();


### PR DESCRIPTION

## ✅ PR 유형
<!-- 필요 없는 유형은 꼭 삭제해주세요. -->
- [x] 버그 수정

<br>

## 📝 작업 내용
> 작업한 내용을 자세하게 설명해주세요. 필요시 스크린샷을 첨부해주세요.
- [x] member - createdAt 이 null로 들어오는 문제 해결
프론트와 연결하는 과정에서 회원 정보 조회를 실행했을 때, 생성날짜가  null로 조회되는 문제를 해결하기 위한 PR입니다.

<br>

## 🔍 테스트 결과
> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

<br>

## 🎈 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항
> 피드백 받은 내용이 있으면 작성해주세요.

<br>

## 💬 리뷰 요구사항
> 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요.
- 회원 정보를 조회하는 로직에서 responseDTO 값을 수정했습니다.

<br>
