### PR TITLE
[Fix] Wallet 게임 결과 처리 포인트 등록 에러

### DIFF
--- a/src/main/java/com/prgrms/ijuju/domain/wallet/dto/request/GamePointRequestDTO.java
+++ b/src/main/java/com/prgrms/ijuju/domain/wallet/dto/request/GamePointRequestDTO.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.prgrms.ijuju.domain.wallet.entity.GameType;
 
 @Getter
@@ -15,6 +17,11 @@ public class GamePointRequestDTO {
     
     private Long memberId;
     private Long points;
-    private boolean isWin;
+    @JsonProperty("isWin") 
+    private boolean win;
     private GameType gameType;
+
+    public boolean isWin() {
+        return win;
+    }
 }


### PR DESCRIPTION
# closed #117 

## #️⃣ 연관된 이슈 번호
related #117 : Wallet 게임 결과 처리 포인트 등록 에러

<br>

## ✅ PR 유형
- [x] 버그 수정

<br>

## 📝 작업 내용
- [x] 게임 결과 처리 후 포인트 등록이 안되는 에러 해결
- [x] 게임에 패배하면 포인트 기록에 저장 안되게 로직 수정
- [x] subType에 게임종류에 성공/실패도 같이 저장되는 에러 해결

![스크린샷 2024-12-06 203342](https://github.com/user-attachments/assets/998251bb-710d-4560-8c27-a70eecdcf27d)


<br>

## 🔍 테스트 결과
- [x] 게임 결과 처리 후 포인트 등록 해결
- [x] 게임에 패배하면 포인트 기록에 저장 안됨
- [x] subType에 게임종류만 기재됨

![스크린샷 2024-12-06 203803](https://github.com/user-attachments/assets/45107b85-19c0-4b9b-b1ad-ad2547954e5d)

<br>

## 🎈 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항

<br>

## 💬 리뷰 요구사항

<br>
