### PR TITLE
[Fix] JwtAuthenticatorFilter 가 웹소켓 인증을 납치하는 문제를 해결

### DIFF
--- a/src/main/java/com/prgrms/ijuju/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/ijuju/global/auth/JwtAuthenticationFilter.java
@@ -80,4 +80,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // WebSocket 요청은 Security 필터를 통과하지 않도록 처리
+        String upgradeHeader = request.getHeader("Upgrade");
+        return upgradeHeader != null && "websocket".equalsIgnoreCase(upgradeHeader);
+    }
 }

--- a/src/main/java/com/prgrms/ijuju/global/auth/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/prgrms/ijuju/global/auth/JwtHandshakeInterceptor.java
@@ -50,7 +50,7 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
             attributes.put("userClaims", claims); // 검증된 클레임을 WebSocket 세션에 저장
             log.info("WebSocket 연결 성공: {}", claims);
             return true;
-            
+
         } catch (Exception e) {
             log.error("JWT 검증 실패: {}", e.getMessage());
             response.setStatusCode(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
JwtAuthenticationFilter 가 WebSocket JwtHandshakeInterceptor 가 진행해야 하는 인증 과정을 납치하는 버그를 픽스 했습니다

# related to #120

<br>

## ✅ PR 유형
<!-- 필요 없는 유형은 꼭 삭제해주세요. -->
- [x] 버그 수정

<br>

## 📝 작업 내용
> 작업한 내용을 자세하게 설명해주세요. 필요시 스크린샷을 첨부해주세요.
- [x] JwtAuthenticationFilter 에 shouldNotFilter 를 사용하여 websocket 요청을 무시하도록 변경



<br>

## 🔍 테스트 결과
> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

<br>

## 🎈 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항
> 피드백 받은 내용이 있으면 작성해주세요.

<br>

## 💬 리뷰 요구사항
> 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요.
ex) Student.java:29 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

<br>
