### PR TITLE
[Feat] OXQuiz 난이도별 하루 제한 구현

### DIFF
--- a/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/controller/OXQuizProgressionController.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/controller/OXQuizProgressionController.java
@@ -24,16 +24,17 @@ public class OXQuizProgressionController {
     @PostMapping("/start")
     public ResponseEntity<List<QuizResponseDto>> getQuizzesForUser(@RequestBody QuizRequestDto requestDTO) {
         Long memberId = requestDTO.getMemberId();
+        String difficulty = requestDTO.getDifficulty();
 
-        if (!progressionService.checkDailyLimit(memberId)) {
+        if (!progressionService.checkDailyLimit(memberId, difficulty)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(Collections.singletonList(
-                            new QuizResponseDto(null, "하루에 한 번만 플레이할 수 있습니다.", null)
+                            new QuizResponseDto(null, "해당 난이도는 하루에 한 번만 플레이할 수 있습니다.", null)
                     ));
         }
         
         List<QuizResponseDto> quizzes = progressionService.getQuizzesForUser(requestDTO.getMemberId(), requestDTO.getDifficulty());
-        progressionService.updateLastPlayedDate(memberId);
+        progressionService.updateLastPlayedDate(memberId, difficulty);
 
         return ResponseEntity.ok(quizzes);
     }

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/entity/OXQuizProgression.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/entity/OXQuizProgression.java
@@ -18,6 +18,8 @@ public class OXQuizProgression {
 
     private Long memberId;
 
-    private LocalDate lastPlayedDate;
+    private LocalDate lastEasyPlayedDate;
+    private LocalDate lastMediumPlayedDate;
+    private LocalDate lastHardPlayedDate;
 
 }

--- a/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/service/OXQuizProgressionService.java
+++ b/src/main/java/com/prgrms/ijuju/domain/minigame/oxquiz/oxquizprogression/service/OXQuizProgressionService.java
@@ -24,23 +24,49 @@ public class OXQuizProgressionService  {
     private final OXQuizProgressionRepository oxQuizProgressionRepository;
     private final OXQuizDataRepository oxQuizDataRepository;
 
-    public boolean checkDailyLimit(Long memberId) {
-        Optional<OXQuizProgression> progression = oxQuizProgressionRepository.findByMemberId(memberId);
+    public boolean checkDailyLimit(Long memberId, String difficulty) {
+        Optional<OXQuizProgression> progressionOpt = oxQuizProgressionRepository.findByMemberId(memberId);
 
-        if (progression.isPresent()) {
-            LocalDate lastPlayedDate = progression.get().getLastPlayedDate();
-            return !LocalDate.now().equals(lastPlayedDate); // 오늘 날짜와 비교
+        if (progressionOpt.isPresent()) {
+            OXQuizProgression progression = progressionOpt.get();
+            LocalDate today = LocalDate.now();
+
+            switch (difficulty.toLowerCase()) {
+                case "easy":
+                    return !today.equals(progression.getLastEasyPlayedDate());
+                case "medium":
+                    return !today.equals(progression.getLastMediumPlayedDate());
+                case "hard":
+                    return !today.equals(progression.getLastHardPlayedDate());
+                default:
+                    throw new IllegalArgumentException("잘못된 난이도: " + difficulty);
+            }
         }
 
         return true; // 진행 상태가 없으면 제한 없음
     }
 
-    public void updateLastPlayedDate(Long memberId) {
+    public void updateLastPlayedDate(Long memberId, String difficulty) {
         OXQuizProgression progression = oxQuizProgressionRepository.findByMemberId(memberId)
                 .orElse(new OXQuizProgression());
 
         progression.setMemberId(memberId);
-        progression.setLastPlayedDate(LocalDate.now());
+
+        LocalDate today = LocalDate.now();
+        switch (difficulty.toLowerCase()) {
+            case "easy":
+                progression.setLastEasyPlayedDate(today);
+                break;
+            case "medium":
+                progression.setLastMediumPlayedDate(today);
+                break;
+            case "hard":
+                progression.setLastHardPlayedDate(today);
+                break;
+            default:
+                throw new IllegalArgumentException("잘못된 난이도: " + difficulty);
+        }
+
         oxQuizProgressionRepository.save(progression);
     }
 


### PR DESCRIPTION
# closed #156


<br>

## ✅ PR 유형
<!-- 필요 없는 유형은 꼭 삭제해주세요. -->
- [x] 새로운 기능 추가

<br>

## 📝 작업 내용
- [x] OXQuiz 단에서 모든 난이도에 대해 하루 한번 제한이던걸 난이도별로 나누어서 구현하였습니다
- [x] field 를 3개로 분할하여, 각각 난이도를 담당하게 한 후 특정 난이도를 다시 부르려고 하면 에러처리 나게 구현



<br>

## 🔍 테스트 결과
> 포스트맨 테스트 결과 이상 없음

<br>

## 🎈 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

<br>

## ✨ 피드백 반영사항
> 피드백 받은 내용이 있으면 작성해주세요.

<br>

## 💬 리뷰 요구사항
> 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요.
ex) Student.java:29 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

<br>
